### PR TITLE
Added RESTRICT_MODE to environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ These are the environment variables you add to web services you want to load-bal
 
 - VIRTUAL_HOST: Domain host name, leave a space for multiple domains. e.g. `www.example.com example.com`
 - FORCE_SSL: Optional. This will use a self-signed cert and redirect traffic to https, its perfect when married to external services like [cloudflare](https://www.cloudflare.com/)
+- RESTRICT_MODE: Optional. Restricts upstream containers. You have the choice between the following modes:
+    - **node**: Only use containers that are on the same node as upstream.
+    - **region**: Only use containers that are in the same region as upstream. e.g. "digitalocean frankfurt 1"
+    - **none**: Does exactly what you think it does.
 
 ## LICENSE
 

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -38,10 +38,11 @@ server {
 }
 
 <% @services.each do |service| %>
+<% next if service.container_ips.nil? %>
 <% if service.host %>
 upstream <%= service.name %> {
-  <% service.containers.each do |container| %>
-  server <%= container.ip%>:80;
+  <% service.container_ips.each do |ip| %>
+  server <%= ip %>:80;
   <% end %>
 }
 

--- a/tutum.rb
+++ b/tutum.rb
@@ -20,7 +20,7 @@ case ENV['RESTRICT_MODE']
     RESTRICT_MODE = :none
 end
 
-# Retrieve the node's fqdn. For 'own nodes' this is an empty string.
+# Retrieve the node's fqdn.
 MY_NODE = ENV['TUTUM_NODE_FQDN']
 
 $stdout.sync = true
@@ -211,6 +211,7 @@ class HttpServices
 
   def get_region_map
     get_nodes.map {
+        # Map the fqdn to the region. For 'own nodes', region is nil.
         |node| { node['external_fqdn'] => node['region'] }
     }.reduce({}) {
         |h,pairs| pairs.each {|k,v| h[k] = v }; h


### PR DESCRIPTION
I've learned a bit ruby to add something I found useful for my use case :)

I added RESTRICT_MODE which can be one of "node" or "region" to filter the upstream containers publicised by the nginx proxy.
- **node**: Only use containers that are on the same node as upstream.
- **region**: Only use containers that are in the same region as upstream. e.g. "digitalocean frankfurt 1"
- **none**: Stick to the default behavior as you code was originally.
